### PR TITLE
Fixed issue of bind volumes to windows containers

### DIFF
--- a/cmd/nerdctl/run_mount.go
+++ b/cmd/nerdctl/run_mount.go
@@ -196,13 +196,21 @@ func generateMountOpts(cmd *cobra.Command, ctx context.Context, client *containe
 		return nil, nil, err
 	} else if len(parsed) > 0 {
 		ociMounts := make([]specs.Mount, len(parsed))
+		var target string
 		for i, x := range parsed {
 			ociMounts[i] = x.Mount
 			mounted[filepath.Clean(x.Mount.Destination)] = struct{}{}
+			if runtime.GOOS == "windows" {
+				target, err = securejoin.SecureJoin(tempDir, strings.Replace(x.Mount.Destination, ":", "", -1))
+				if err != nil {
+					return nil, nil, err
+				}
+			} else {
+				target, err = securejoin.SecureJoin(tempDir, x.Mount.Destination)
+				if err != nil {
+					return nil, nil, err
+				}
 
-			target, err := securejoin.SecureJoin(tempDir, x.Mount.Destination)
-			if err != nil {
-				return nil, nil, err
 			}
 
 			//Copying content in AnonymousVolume and namedVolume

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -68,8 +68,10 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 	case 2, 3, 4:
 		res.Type = Bind
 		if len(split) == 4 { //For binding volumes to windows containers
-			src = split[0] + ":" + split[1]
-			dst = split[2] + ":" + split[3]
+			src, dst = split[0]+":"+split[1], split[2]+":"+split[3]
+		} else if len(split) == 3 { //For binding named volume
+			src, dst = split[0], split[1]+":"+split[2]
+
 		} else {
 			src, dst = split[0], split[1]
 		}

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -65,10 +65,15 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 		}
 		src = anonVol.Mountpoint
 		res.Type = Volume
-	case 2, 3:
+	case 2, 3, 4:
 		res.Type = Bind
-		src, dst = split[0], split[1]
-		if !strings.Contains(src, "/") {
+		if len(split) == 4 { //For binding volumes to windows containers
+			src = split[0] + ":" + split[1]
+			dst = split[2] + ":" + split[3]
+		} else {
+			src, dst = split[0], split[1]
+		}
+		if !strings.Contains(src, "/") && !strings.Contains(src, "\\") {
 			// assume src is a volume name
 			vol, err := volStore.Get(src)
 			if err != nil {
@@ -115,7 +120,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 
 	fstype := "nullfs"
 	if runtime.GOOS != "freebsd" {
-		fstype = "none"
+		fstype = ""
 		options = append(options, "rbind")
 	}
 	res.Mount = specs.Mount{


### PR DESCRIPTION
### Fixed issue 759:
- volume binding issue in Windows containers
```
D:\GolandProjects\github.com\nerdctl\cmd\nerdctl>nerdctl run -it -v C:\ProgramData\nerdctl\052055e3\volumes\default\test007:C:\src123 rancher/windows_exporter-package:v0.0.3-windows-20H2 cmd.exe
Microsoft Windows [Version 10.0.19042.1348]
(c) Microsoft Corporation. All rights reserved.

C:\Windows\system32>cd ../..

C:\>dir
 Volume in drive C has no label.
 Volume Serial Number is C494-B48A

 Directory of C:\

11/17/2021  12:08 AM               771 entry.ps1
11/17/2021  12:13 AM    <DIR>          etc
09/11/2020  02:04 AM             5,510 License.txt
11/04/2021  02:36 AM    <DIR>          Program Files
11/04/2021  02:36 AM    <DIR>          Program Files (x86)
03/10/2022  12:36 PM    <DIR>          src123
11/04/2021  02:58 AM    <DIR>          Users
11/17/2021  12:13 AM    <DIR>          Windows
               2 File(s)          6,281 bytes
               6 Dir(s)  21,245,403,136 bytes free

C:\>

```
When using nerdctl + containerd on Windows, I am able to mount volumes or bind mount to a new windows container.
